### PR TITLE
Asymptotic runtime improvement

### DIFF
--- a/cozy/cost_model.py
+++ b/cozy/cost_model.py
@@ -149,7 +149,7 @@ def hash_cost(e):
 def comparison_cost(e1, e2):
     return ESum([storage_size(e1), storage_size(e2)])
 
-def wc_card(e):
+def wc_card(e : Exp) -> DominantTerm:
     assert is_collection(e.type)
     while isinstance(e, EFilter) or isinstance(e, EMap) or isinstance(e, EFlatMap) or isinstance(e, EMakeMap2) or isinstance(e, EStateVar) or (isinstance(e, EUnaryOp) and e.op == UOp.Distinct) or isinstance(e, EListSlice):
         e = e.e
@@ -177,6 +177,11 @@ LINEAR_TIME_UOPS = {
 
 @functools.total_ordering
 class DominantTerm(object):
+    """A term of the form c*n^e for some unknown n.
+
+    Instances of this class can be added, multiplied, and compared.  A term
+    with a higher exponent is always greater than one with a lower exponent.
+    """
     __slots__ = ("multiplier", "exponent")
     def __init__(self, multiplier, exponent):
         self.multiplier = multiplier
@@ -202,7 +207,7 @@ DominantTerm.ZERO = DominantTerm(0, 0)
 DominantTerm.ONE  = DominantTerm(1, 0)
 DominantTerm.N    = DominantTerm(1, 1)
 
-def asymptotic_runtime(e : Exp) -> int:
+def asymptotic_runtime(e : Exp) -> DominantTerm:
     res = DominantTerm.ZERO
     stk = [e]
     while stk:

--- a/cozy/cost_model.py
+++ b/cozy/cost_model.py
@@ -2,6 +2,7 @@
 
 from collections import OrderedDict
 from enum import Enum
+import functools
 
 from cozy.common import OrderedSet
 from cozy.target_syntax import *
@@ -155,16 +156,16 @@ def wc_card(e):
     if isinstance(e, EBinOp) and e.op == "-":
         return wc_card(e.e1)
     if isinstance(e, EBinOp) and e.op == "+":
-        return max(wc_card(e.e1), wc_card(e.e2))
+        return wc_card(e.e1) + wc_card(e.e2)
     if isinstance(e, EFlatMap):
         return wc_card(e.e) * wc_card(e.f.body)
     if isinstance(e, ECond):
         return max(wc_card(e.then_branch), wc_card(e.else_branch))
     if isinstance(e, EEmptyList):
-        return 0
+        return DominantTerm.ZERO
     if isinstance(e, ESingleton):
-        return 1
-    return EXTREME_COST
+        return DominantTerm.ONE
+    return DominantTerm.N
 
 # These require walking over the entire collection.
 # Some others (e.g. "exists" or "empty") just look at the first item.
@@ -174,8 +175,35 @@ LINEAR_TIME_UOPS = {
     UOp.All, UOp.Any,
     UOp.Reversed }
 
+@functools.total_ordering
+class DominantTerm(object):
+    __slots__ = ("multiplier", "exponent")
+    def __init__(self, multiplier, exponent):
+        self.multiplier = multiplier
+        self.exponent = exponent
+    def __eq__(self, other):
+        return self.multiplier == other.multiplier and self.exponent == other.exponent
+    def __lt__(self, other):
+        return (self.exponent, self.multiplier) < (other.exponent, other.multiplier)
+    def __str__(self):
+        return "{}n^{}".format(self.multiplier, self.exponent)
+    def __repr__(self):
+        return "DominantTerm({}, {})".format(self.multiplier, self.exponent)
+    def __add__(self, other):
+        if other.exponent == self.exponent:
+            return DominantTerm(self.multiplier + other.multiplier, self.exponent)
+        if other.exponent > self.exponent:
+            return other
+        return self
+    def __mul__(self, other):
+        return DominantTerm(self.multiplier * other.multiplier, self.exponent + other.exponent)
+
+DominantTerm.ZERO = DominantTerm(0, 0)
+DominantTerm.ONE  = DominantTerm(1, 0)
+DominantTerm.N    = DominantTerm(1, 1)
+
 def asymptotic_runtime(e : Exp) -> int:
-    res = 0
+    res = DominantTerm.ZERO
     stk = [e]
     while stk:
         e = stk.pop()
@@ -187,11 +215,12 @@ def asymptotic_runtime(e : Exp) -> int:
         if isinstance(e, ELambda):
             e = e.body
         if isinstance(e, EFilter):
-            res += max(wc_card(e.e) * asymptotic_runtime(e.p), asymptotic_runtime(e.e))
+            res += wc_card(e.e) * asymptotic_runtime(e.p) + asymptotic_runtime(e.e)
             continue
         if isinstance(e, EMap) or isinstance(e, EFlatMap) or isinstance(e, EArgMin) or isinstance(e, EArgMax):
-            res += max(wc_card(e.e) * asymptotic_runtime(e.f), asymptotic_runtime(e.e))
+            res += wc_card(e.e) * asymptotic_runtime(e.f) + asymptotic_runtime(e.e)
             continue
+        res += DominantTerm.ONE
         if isinstance(e, EMakeMap2):
             res += wc_card(e.e) * asymptotic_runtime(e.value)
         if isinstance(e, EBinOp) and e.op == BOp.In:
@@ -207,7 +236,7 @@ def asymptotic_runtime(e : Exp) -> int:
         if isinstance(e, EStateVar):
             continue
         stk.extend(e.children())
-    return max(res, 1)
+    return res
 
 def is_constant_time(e : Exp) -> bool:
     return asymptotic_runtime(e) < EXTREME_COST

--- a/cozy/cost_model.py
+++ b/cozy/cost_model.py
@@ -236,6 +236,8 @@ def asymptotic_runtime(e : Exp) -> int:
         if isinstance(e, EStateVar):
             continue
         stk.extend(e.children())
+    if res.exponent == 0:
+        return DominantTerm.ONE
     return res
 
 def is_constant_time(e : Exp) -> bool:

--- a/cozy/cost_model.py
+++ b/cozy/cost_model.py
@@ -241,7 +241,7 @@ def asymptotic_runtime(e : Exp) -> int:
     return res
 
 def is_constant_time(e : Exp) -> bool:
-    return asymptotic_runtime(e) < EXTREME_COST
+    return asymptotic_runtime(e).exponent == 0
 
 # Some kinds of expressions have a massive penalty associated with them if they
 # appear at runtime.


### PR DESCRIPTION
This changeset makes `asymptotic_runtime` a lot more precise without sacrificing much speed. Instead of returning an int, it now returns a `DominantTerm` that captures the constant factor and exponent of the worst-case runtime.