### PR TITLE
Call precondition checking

### DIFF
--- a/cozy/desugar.py
+++ b/cozy/desugar.py
@@ -70,19 +70,6 @@ def desugar(spec : Spec) -> Spec:
 
     assert retypecheck(spec, env={})
 
-    # organize queries by name
-    queries = { q.name : q for q in spec.methods if isinstance(q, Query) }
-
-    class V(BottomUpRewriter):
-        def visit_ECall(self, e):
-            q = queries.get(e.func)
-            if q is not None:
-                return self.visit(subst(q.ret, { arg_name: arg for ((arg_name, ty), arg) in zip(q.args, e.args) }))
-            else:
-                return ECall(e.func, tuple(self.visit(a) for a in e.args)).with_type(e.type)
-    spec = V().visit(spec)
-    spec.methods = [m for m in spec.methods if not (isinstance(m, Query) and m.visibility == Visibility.Private)]
-
     class V(BottomUpRewriter):
         def visit_Exp(self, e):
             return desugar_list_comprehensions(e)

--- a/cozy/main.py
+++ b/cozy/main.py
@@ -71,12 +71,16 @@ def run():
 
         ast = desugar.desugar(ast)
         ast = invariant_preservation.add_implicit_handle_assumptions(ast)
+
+        print("Checking call legality...")
+        call_errors = invariant_preservation.check_calls_wf(ast)
         ast = syntax_tools.inline_calls(ast)
 
         print("Checking assumptions...")
         errors = (
             invariant_preservation.check_ops_preserve_invariants(ast) +
-            invariant_preservation.check_the_wf(ast))
+            invariant_preservation.check_the_wf(ast) +
+            call_errors)
         if errors:
             for e in errors:
                 print("Error: {}".format(e))

--- a/cozy/main.py
+++ b/cozy/main.py
@@ -71,6 +71,7 @@ def run():
 
         ast = desugar.desugar(ast)
         ast = invariant_preservation.add_implicit_handle_assumptions(ast)
+        ast = syntax_tools.inline_calls(ast)
 
         print("Checking assumptions...")
         errors = (

--- a/cozy/main.py
+++ b/cozy/main.py
@@ -76,7 +76,7 @@ def run():
         call_errors = invariant_preservation.check_calls_wf(ast)
         ast = syntax_tools.inline_calls(ast)
 
-        print("Checking assumptions...")
+        print("Checking invariant preservation...")
         errors = (
             invariant_preservation.check_ops_preserve_invariants(ast) +
             invariant_preservation.check_the_wf(ast) +

--- a/cozy/syntax_tools.py
+++ b/cozy/syntax_tools.py
@@ -1503,7 +1503,10 @@ def cse(e, verify=False):
             assert False
     return res
 
-def inline_calls(spec):
+def inline_calls(spec, target=None):
+    if target is None:
+        target = spec
+
     extern_func_names = set(e.name for e in spec.extern_funcs)
     queries = {q.name : q for q in spec.methods if isinstance(q, syntax.Query)}
 
@@ -1524,7 +1527,7 @@ def inline_calls(spec):
                 {arg: self.visit(expr) for ((arg, argtype), expr) in zip(query.args, e.args)}))
 
     rewriter = CallInliner()
-    return rewriter.visit(spec)
+    return rewriter.visit(target)
 
 def get_modified_var(stm):
     """

--- a/cozy/syntax_tools.py
+++ b/cozy/syntax_tools.py
@@ -1520,8 +1520,8 @@ def inline_calls(spec):
             if query is None:
                 return e
 
-            return subst(query.ret,
-                {arg: self.visit(expr) for ((arg, argtype), expr) in zip(query.args, e.args)})
+            return self.visit(subst(query.ret,
+                {arg: self.visit(expr) for ((arg, argtype), expr) in zip(query.args, e.args)}))
 
     rewriter = CallInliner()
     return rewriter.visit(spec)


### PR DESCRIPTION
Cozy allows you to call queries in other queries. It also allows you to define preconditions on queries. However, it does not currently check whether the preconditions to a call are satisfied at the call site.

This changeset adds that checking, thus addressing one of the points in #23.