### PR TITLE
ambiguous empty issue (WIP)

### DIFF
--- a/examples/argmin.ds
+++ b/examples/argmin.ds
@@ -9,6 +9,10 @@ MinFinder:
         assume exists xs;
         argmin {x -> x.val} xs
 
+    // this should return null if xs is empty
+    query findmin2()
+        argmin {x -> x.val} xs
+
     op chval(x : T, nv : Native "int")
         assume x in xs;
         assume x.val != nv;


### PR DESCRIPTION
We should fix this to let argmin/max return null if the argument list is
empty.
this should simplify a lot of real world code, e.g.
datastructure-synthesizer/followup/eval/mongo/spec.ds

Test:
    cozy argmin.ds