### PR TITLE
Improve flatMap handling

### DIFF
--- a/cozy/synthesis/acceleration.py
+++ b/cozy/synthesis/acceleration.py
@@ -308,7 +308,7 @@ def optimized_exists(xs):
     if isinstance(xs, EFilter):
         return optimized_any_matches(xs.e, xs.predicate)
     elif isinstance(xs, EStateVar):
-        return EStateVar(EUnaryOp(UOp.Exists, xs.e).with_type(BOOL)).with_type(BOOL)
+        return statevar(EUnaryOp(UOp.Exists, xs.e), BOOL)
     elif isinstance(xs, EBinOp) and xs.op == "+":
         return EAny([
             optimized_exists(xs.e1),
@@ -429,7 +429,7 @@ def optimized_best(xs, keyfunc, op, args):
                 xs.transform_function.apply_to(b),
                 construct_value(elem_type))
     if isinstance(xs, EStateVar) and not any(v in args for v in free_vars(keyfunc)):
-        yield EStateVar(argbest(xs.e, keyfunc).with_type(elem_type)).with_type(elem_type)
+        yield statevar(argbest(xs.e, keyfunc), elem_type)
     if isinstance(xs, ECond):
         for a in optimized_best(xs.then_branch, keyfunc, op, args=args):
             for b in optimized_best(xs.else_branch, keyfunc, op, args=args):
@@ -657,7 +657,7 @@ def optimized_the(xs, args):
             for e2 in optimized_the(xs.else_branch, args):
                 yield optimized_cond(xs.cond, e1, e2)
     if isinstance(xs, EStateVar):
-        yield EStateVar(EUnaryOp(UOp.The, xs.e).with_type(t)).with_type(t)
+        yield statevar(EUnaryOp(UOp.The, xs.e), t)
     if isinstance(xs.type, TList):
         x = excluded_element(xs, args)
         if x is not None:
@@ -680,7 +680,7 @@ def optimized_distinct(xs, args):
         yield xs
         return
     if isinstance(xs, EStateVar):
-        yield EStateVar(EUnaryOp(UOp.Distinct, xs.e).with_type(xs.type)).with_type(xs.type)
+        yield statevar(EUnaryOp(UOp.Distinct, xs.e), xs.type)
     if isinstance(xs, EBinOp):
         if xs.op == "+":
             v = fresh_var(xs.type.elem_type)

--- a/cozy/synthesis/acceleration.py
+++ b/cozy/synthesis/acceleration.py
@@ -630,7 +630,7 @@ sum_of = lambda xs: EUnaryOp(UOp.Sum, xs).with_type(xs.type.elem_type)
 def optimized_sum(xs, args):
     elem_type = xs.type.elem_type
     if isinstance(xs, EStateVar):
-        yield EStateVar(sum_of(xs)).with_type(elem_type)
+        yield EStateVar(sum_of(strip_EStateVar(xs))).with_type(elem_type)
     if isinstance(xs, EBinOp) and xs.op == "+":
         for a in optimized_sum(xs.e1, args=args):
             for b in optimized_sum(xs.e2, args=args):

--- a/cozy/target_syntax.py
+++ b/cozy/target_syntax.py
@@ -19,6 +19,9 @@ EStm       = declare_case(Exp, "EStm", ["stm", "out_var"])
 # State var barrier: sub-expression should be maintained as a fresh state var
 EStateVar  = declare_case(Exp, "EStateVar", ["e"])
 
+def statevar(e, ty):
+    return EStateVar(e.with_type(ty)).with_type(ty)
+
 def EIsSingleton(e):
     arg = EVar(fresh_name()).with_type(e.type.elem_type)
     return EBinOp(EUnaryOp(UOp.Sum, EMap(e, ELambda(arg, ONE)).with_type(TBag(INT))).with_type(INT), "<=", ONE).with_type(BOOL)

--- a/docs/Developer.md
+++ b/docs/Developer.md
@@ -1,0 +1,5 @@
+Developer Notes
+======
+
+- `check_wf` can decide whether a candidate expression is applied
+    + `allow-big-sets/maps` is used here

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -14,11 +14,13 @@ guava-23.0.jar:
 
 java: MaxBag.class MaxBagMain.class LSort.class
 
+TIMEOUT ?= 240
+
 listcomp.h: listcomp-flatmap.ds
-	cozy listcomp-flatmap.ds --c++ listcomp.h
+	cozy -t $(TIMEOUT) --allow-big-sets listcomp-flatmap.ds --c++ listcomp.h -p 8080 --verbose --save listcomp.synthesized
 
 listcomp: listcomp.cpp listcomp.h
-	g++ -O3 -Werror '$<' -o '$@'
+	g++ -std=c++11 -O3 -Werror '$<' -o '$@'
 
 run-listcomp: listcomp
 	time ./listcomp

--- a/examples/listcomp-flatmap.ds
+++ b/examples/listcomp-flatmap.ds
@@ -8,12 +8,14 @@ ListComp02:
         C: Int
     }
 
+    extern mul(i : Int, j : Int) : Int = "{i} * {j}"
+
     state Rs : Bag<R>
     state Ss : Bag<S>
 
     // the resulted flatMap can't be reduced easily
     query q()
-        [(r, s) | r <- Rs, s <- Ss ]
+        sum [ mul(r.A, s.C) | r <- Rs, s <- Ss ]
 
     op insert_r(r: R)
         Rs.add(r);

--- a/examples/listcomp.cpp
+++ b/examples/listcomp.cpp
@@ -7,9 +7,6 @@
 
 using namespace std::chrono;
 
-void cb(ListComp02::_Type114907 e) {
-}
-
 constexpr int max_iter = 10000;
 
 int main(int argc, char const *argv[])
@@ -19,16 +16,17 @@ int main(int argc, char const *argv[])
         system_clock::now().time_since_epoch()
     );
     long initial_count = ms.count();
+    long total = 0;
     for (int i = 0; i <max_iter; i++) {
         if (i % (max_iter / 100) == 0) {
             milliseconds ms = duration_cast< milliseconds >(
                 system_clock::now().time_since_epoch()
             );
-            std::cout << i << " " << ms.count() - initial_count << std::endl;
+            std::cout << i << " " << ms.count() - initial_count << " " << total << std::endl;
         }
         l.insert_r(ListComp02::R(1, ""));
         l.insert_s(ListComp02::S("a", 2));
-        l.q(cb);
+        total += l.q();
     }
     return 0;
 }


### PR DESCRIPTION
## Test

```
$ cd examples
$ make listcomp TIMEOUT=1 
cozy -t 1 --allow-big-sets listcomp-flatmap.ds --c++ listcomp.h -p 8080 --save listcomp.synthesized
...
Number of improvements done: 8
g++ -std=c++11 -O3 -Werror 'listcomp.cpp' -o 'listcomp'
$ ./listcomp 
0 0 0
100 18 676700
200 108 5373400
300 323 18090100
400 742 42826800
500 1413 83583500
600 2415 144360200
700 3815 229156900
800 5673 341973600
900 8057 486810300
^C
$ rm listcomp.h          
$ make listcomp TIMEOUT=10
cozy -t 10 --allow-big-sets listcomp-flatmap.ds --c++ listcomp.h -p 8080 --save listcomp.synthesized
...
Number of improvements done: 20
g++ -std=c++11 -O3 -Werror 'listcomp.cpp' -o 'listcomp'
$ ./listcomp              
0 0 0
100 0 676700
200 0 5373400
300 1 18090100
400 1 42826800
500 2 83583500
600 2 144360200
700 3 229156900
800 4 341973600
900 5 486810300
....
9900 358 646964013300
```

In the output of `./listcomp`, the columns are: "current size of bag", "milliseconds between this and previous row", "accumulated sum". For details, please see `examples/listcomp.cpp`. From the second row, it is clear that the optimized flatMap makes the program much faster (see TODO graph). The third row are same across two runs, which validates the correctness of synthesis.


![Figure_1](https://user-images.githubusercontent.com/7168454/61585408-06f15980-ab29-11e9-9cf6-2b5bc0621c8b.png)
