### PR TITLE
Save before cleaning up threads

### DIFF
--- a/cozy/main.py
+++ b/cozy/main.py
@@ -101,7 +101,12 @@ def run():
 
     start = datetime.datetime.now()
 
-    if not args.simple:
+    if args.simple:
+        if args.save:
+            with open(args.save, "wb") as f:
+                pickle.dump(ast, f)
+                print("Saved implementation to file {}".format(args.save))
+    else:
         callback = None
         server = None
 
@@ -146,15 +151,11 @@ def run():
             ast,
             timeout           = datetime.timedelta(seconds=args.timeout),
             progress_callback = callback,
-            improve_count=improve_count)
+            improve_count=improve_count,
+            dump_synthesized_in_file=args.save)
 
         if server is not None:
             server.join()
-
-    if args.save:
-        with open(args.save, "wb") as f:
-            pickle.dump(ast, f)
-            print("Saved implementation to file {}".format(args.save))
 
     print("Generating IR...")
     code = ast.code


### PR DESCRIPTION
A partial solution to deal with #110: since cleaning up thread can take a long time, we can try to first save the current synthesized solution and then work on cleaning up, which might take a long time.