### PR TITLE
Use backend specific implementation for UOp.Length

### DIFF
--- a/cozy/codegen/cxx.py
+++ b/cozy/codegen/cxx.py
@@ -426,7 +426,10 @@ class CxxPrinter(CodeGenerator):
             self.declare(v, e.e)
             self.visit(self.reverse_inplace(v))
             return v.id
-        elif op in (UOp.Distinct, UOp.AreUnique, UOp.Length, UOp.Sum, UOp.All, UOp.Any, UOp.Exists, UOp.Empty, UOp.The):
+        elif op == UOp.Length:
+            ee = self.visit(e.e)
+            return "({}.size())".format(ee)
+        elif op in (UOp.Distinct, UOp.AreUnique, UOp.Sum, UOp.All, UOp.Any, UOp.Exists, UOp.Empty, UOp.The):
             raise Exception("{!r} operator is supposed to be handled by simplify_and_optimize".format(op))
         else:
             raise NotImplementedError(op)

--- a/cozy/codegen/java.py
+++ b/cozy/codegen/java.py
@@ -9,7 +9,7 @@ from cozy.syntax import (
     TBag, TSet, TList,
     Exp, ENum, ONE, ZERO, EVar, EBinOp, EEmptyList, ENull, ETuple, EMakeRecord,
     EEq, ENot, EAll, ECond,
-    SNoOp, SAssign, SForEach, seq, SDecl, ELt)
+    SNoOp, SAssign, SForEach, seq, SDecl, ELt, UOp)
 from cozy.target_syntax import TMap, EMapGet, SWhile, SReturn
 from cozy.syntax_tools import free_vars, subst, all_exps
 from cozy.typecheck import is_scalar, is_collection
@@ -139,6 +139,13 @@ class JavaPrinter(CxxPrinter):
     def visit_EEmptyList(self, e):
         t = self.visit(e.type, "()")
         return "new " + t
+
+    def visit_EUnaryOp(self, e):
+        op = e.op
+        if op == UOp.Length:
+            ee = self.visit(e.e)
+            return "({}.size())".format(ee)
+        return super().visit_EUnaryOp(e)
 
     def visit_EEmptyMap(self, e):
         map_type = e.type

--- a/cozy/codegen/optimization.py
+++ b/cozy/codegen/optimization.py
@@ -368,9 +368,6 @@ class ExpressionOptimizer(BottomUpRewriter):
                 SForEach(loop_var, e.e,
                     SAssign(sum_var, EBinOp(sum_var, "+", loop_var).with_type(INT)))])))
             return sum_var
-        elif op == UOp.Length:
-            arg = EVar("x").with_type(e.e.type.elem_type)
-            return self.visit(EUnaryOp(UOp.Sum, EMap(e.e, ELambda(arg, ONE)).with_type(INT_BAG)).with_type(INT))
         elif op == UOp.All:
             arg = EVar("x").with_type(e.e.type.elem_type)
             return self.visit(EUnaryOp(UOp.Empty, EFilter(e.e, ELambda(arg, ENot(arg))).with_type(INT_BAG)).with_type(INT))

--- a/cozy/codegen/ruby.py
+++ b/cozy/codegen/ruby.py
@@ -7,7 +7,7 @@ from cozy.syntax import (
     TBag, TSet, TList,
     Exp, ENum, EVar, ETuple, ETupleGet,
     ENot, EGetField, EEnumEntry,
-    SNoOp, SAssign, SDecl)
+    SNoOp, SAssign, SDecl, UOp)
 from cozy.target_syntax import EMapGet, SReturn
 from cozy.syntax_tools import all_exps
 from cozy.typecheck import is_scalar
@@ -148,6 +148,13 @@ class RubyPrinter(CxxPrinter):
             self.visit(simplify_and_optimize(SReturn(q.ret)))
         self.write("end")
         self.end_statement()
+
+    def visit_EUnaryOp(self, e):
+        op = e.op
+        if op == UOp.Length:
+            ee = self.visit(e.e)
+            return "({}.length)".format(ee)
+        return super().visit_EUnaryOp(e)
 
     def visit_EEmptyList(self, e):
         return "[]"

--- a/examples/intset.ds
+++ b/examples/intset.ds
@@ -1,4 +1,4 @@
-ClauseDB:
+Intset:
 
     state ints : Set<Int>
 


### PR DESCRIPTION
... which is faster than sum(map(xs, lambda _: 1))

Test:

```
cd examples
cozy intset.ds --c++ intset.hpp -t 30
cozy intset.ds --java Intset.java -t 30
cozy intset.ds --ruby intset.rb -t 30
```